### PR TITLE
Update README with better installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ This work tries to automate the monitoring of whether people are wearing hardhat
 2. Clone the SSD-RPA repository and compile the code.
 
    ```shell
-   git clone https://github.com/wujixiu/helmet-detection/tree/master/hardhat-wearing-detection/SSD-RPA.git
+   git clone https://github.com/wujixiu/helmet-detection.git
    
-   cd SSD-RPA
+   cd cd helmet-detection/hardhat-wearing-detection/SSD-RPA/
    
    make all -j8
    ```


### PR DESCRIPTION
Running the installation gave errors for my peers and myself. Changing the installation instructions so no errors get thrown.

When I initially git cloned your example, I got "/' not found."